### PR TITLE
Fix service file location on aarch64

### DIFF
--- a/daemon/daemon.pro
+++ b/daemon/daemon.pro
@@ -11,20 +11,6 @@ QMAKE_CXXFLAGS += -std=c++0x
 
 DEFINES += APP_VERSION=\\\"$$VERSION\\\"
 
-linux-g++{
-   !contains(QT_ARCH, arm64){
-       LIB=lib
-       message("Building for 32bit system")
-    } else {
-       LIB=lib64
-       message("Building for 64bit system")
-   }
-}
-linux-g++-32 {
-    message("Building for emulator / jolla tablet (i486)")
-    LIB=lib
-}
-
 SOURCES += \
     daemon.cpp \
     dbusadapter.cpp \
@@ -68,7 +54,7 @@ INSTALLS += target sysmond
 target.path = /usr/bin
 
 sysmond.files = $${TARGET}.service
-sysmond.path = /usr/$${LIB}/systemd/user
+sysmond.path = /usr/lib/systemd/user
 
 #qtcreator is bugged
 INCLUDEPATH += $$[QT_HOST_PREFIX]/include/mlite5

--- a/rpm/harbour-systemmonitor.spec
+++ b/rpm/harbour-systemmonitor.spec
@@ -26,6 +26,7 @@ BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Quick)
 BuildRequires:  pkgconfig(keepalive)
+BuildRequires:  pkgconfig(mlite5)
 BuildRequires:  desktop-file-utils
 
 %description
@@ -97,6 +98,6 @@ systemctl-user start %{name}d || true
 %{_datadir}/%{name}
 %{_datadir}/applications/%{name}.desktop
 %{_datadir}/icons/hicolor/86x86/apps/%{name}.png
-%{_libdir}/systemd/user/%{name}d.service
+%{_userunitdir}/%{name}d.service
 # >> files
 # << files


### PR DESCRIPTION
Funnily enough, SailfishOS uses /usr/lib/systemd even on 64bit so all that lib/lib64 checking isn't necessary, and the service won't start.

Also added mlite5 BuildRequires so this can be built on OBS.